### PR TITLE
Fix trailing question mark in CLI episode objective

### DIFF
--- a/episodes/cli.md
+++ b/episodes/cli.md
@@ -16,7 +16,7 @@ exercises: 2
 
 - Learn what a command-line interface is
 - Understand the benefits of <acronym title="command-line interfaces">CLIs</acronym> for making research code more
-  accessible?
+  accessible
 - Gain a basic familiarity with the `argparse` module in Python
 
 ::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
## Summary
- Removes erroneous `?` from the end of the "Understand the benefits of CLIs..." learning objective in `episodes/cli.md`

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)