### PR TITLE
Fix broken bash examples in readmes episode

### DIFF
--- a/episodes/readmes.md
+++ b/episodes/readmes.md
@@ -98,7 +98,7 @@ These steps may be achieved using the terminal as follows:
 ```bash
 mkdir oddsong
 touch oddsong/README.txt
-echo "This is my code" >> my_project/oddsong.txt
+echo "This is my code" >> oddsong/README.txt
 nano oddsong/README.txt
 ```
 
@@ -112,7 +112,7 @@ These steps may be achieved using the terminal as follows:
 ```bash
 mkdir oddsong
 touch oddsong/README.txt
-echo "This is my code" >> my_project/oddsong.txt
+echo "This is my code" >> oddsong/README.txt
 nano oddsong/README.txt
 ```
 


### PR DESCRIPTION
## Summary

- Fixes two broken `echo` commands in `episodes/readmes.md` (lines 101 and 115)
- Both referenced `my_project/oddsong.txt` which doesn't exist; corrected to `oddsong/README.txt`

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)