### PR TITLE
fix(examples): correct R code typos in examples episode

### DIFF
--- a/episodes/examples.md
+++ b/episodes/examples.md
@@ -132,7 +132,7 @@ aren't relevant. This code has plenty of documentation to help us read and under
 #'
 #' @param angle The angle in radians.
 #'
-#' @returns The sine of the angle (sun(angle)).
+#' @returns The sine of the angle (sin(angle)).
 calculate_sine <- function(angle) {
   sine_value <- angle
 
@@ -145,7 +145,7 @@ calculate_sine <- function(angle) {
     sine_value <- sine_value + sign * (angle^(2 * i)) / factorial
   }
 
-  return(sin_value)
+  return(sine_value)
 }
 ```
 
@@ -163,7 +163,7 @@ Read and evaluate this code.
 
 This time, the function name is a verb that describes what the code will attempt to do. The description of the function
 is also written out clearly in a note for the user. There are comment lines (starting with `#`) that explain the
-mathematicalal method used. Each variable has a descriptive, human-readable name, making the code more intuitive to
+mathematical method used. Each variable has a descriptive, human-readable name, making the code more intuitive to
 read. An existing library is used to calculate the factorial, which means we can look up the usage for the `factorial()`
 function elsewhere.
 


### PR DESCRIPTION
## Summary
- Fix `sun(angle)` → `sin(angle)` typo in `@returns` docstring
- Fix `return(sin_value)` → `return(sine_value)` runtime error
- Fix `mathematicalal` → `mathematical` typo

Closes #78

## Test plan
- [ ] Verify the R code example renders correctly on the published site
- [ ] Confirm the code would now run without errors if executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)