### PR TITLE
Add system setup to instructor notes and improve learner setup page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,21 @@ Published at <https://fair2-for-research-software.github.io/Documentation/>.
 - `links.md` — shared link definitions used across episodes
 - `site/` — auto-generated; do not edit
 
-## Linting
+## Running commands
+
+Use `pixi` to run general utility commands — it manages the project's
+conda environment and exposes tasks defined in `pixi.toml`.
 
 ```bash
-pre-commit run --all-files          # all checks
-pre-commit run markdownlint-cli2 --all-files
-pre-commit run codespell --all-files
+pixi run lint                       # pre-commit run --all-files
+pixi run spellcheck                 # codespell
+pixi run build                      # sandpaper::build_lesson()
+pixi run serve                      # sandpaper::serve()
+pixi run check                      # sandpaper::check_lesson()
 ```
+
+For ad-hoc commands not defined as tasks, use `pixi run <command>`
+(e.g. `pixi run pre-commit run markdownlint-cli2 --all-files`).
 
 Markdownlint runs with `fix: true` — it auto-corrects on pre-commit.
 

--- a/episodes/contributors.md
+++ b/episodes/contributors.md
@@ -143,6 +143,10 @@ For many working in a research context, there are additional considerations to e
 ethics, and data protection regulations are carefully observed. These protocols are outside the scope of this document,
 but these factors should be clearly communicated to all contributors.
 
+When you place a `CODE_OF_CONDUCT.md` file in the root of your repository, GitHub will recognise it as a [community
+health file](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)
+and render it as a dedicated tab on the repository's home page, making it easy for contributors to find.
+
 :::: callout
 
 ### Contributor Covenant

--- a/episodes/contributors.md
+++ b/episodes/contributors.md
@@ -152,6 +152,20 @@ which is a template charter that may be customised to suit the needs of your col
 
 ::::
 
+:::: challenge
+
+Create a new file called `CODE_OF_CONDUCT.md` in the root of your project and draft a short code of conduct for your
+contributors.
+
+- What behaviours do you want to encourage in your community?
+- What behaviours are unacceptable?
+- How should people report concerns, and who is responsible for responding?
+
+You may wish to start from the [Contributor Covenant](https://www.contributor-covenant.org/) template and adapt it to
+suit your project.
+
+::::
+
 ## Developer notes
 
 It's useful to write guidance for software engineers who will contribute new features and improvements to the research

--- a/episodes/readable.md
+++ b/episodes/readable.md
@@ -138,7 +138,7 @@ I'd rather work in.
 ### Code editors
 
 To work with our source code in a colourised way like this, use a text editor or <abbr title="Integrated development
-environment">IDE</abbr> with a syntax highlighting feature such as Notepad++, VSCode, PyCharm, or RStudio.
+environment">IDE</abbr> with a syntax highlighting feature such as VSCode, PyCharm, or RStudio.
 
 ::::::::::::::::::::::::::::::::::::: challenge
 

--- a/episodes/readmes.md
+++ b/episodes/readmes.md
@@ -449,8 +449,7 @@ These subheadings help the users to navigate the document.
 
 There are several ways to view the formatted Markdown document, where the syntax is rendered into a rich text document.
 
-- Many code editors have an in-built Markdown viewer;
-  - For Notepad++, the Markdown Panel [plugin may be installed](https://npp-user-manual.org/docs/plugins/).
+- Many code editors have an in-built Markdown viewer.
 - [Markdown Live Preview](https://markdownlivepreview.com/) is a web-based tool. Input your Markdown syntax in the left
   panel and the result will be displayed on the right-hand side.
 - In [Google Colab](https://colab.research.google.com/), the Text cells use Markdown syntax for formatting.

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -9,5 +9,44 @@ The slides for this lesson are available on [Google Slides](https://docs.google.
 The presentation course of this course should be modified depending on the target audience.
 
 Many beginner coders in the research world will not need to know advanced skills such as how to automatically generate
-and deploy documentation websites, but some introductory material on this topic is here if required.  In most cases,
-**only present episodes one to four** during the workshop.
+and deploy documentation websites, but some introductory material on this topic is here if required.
+
+## System Setup
+
+Run through the following pre-flight checks with learners at the start of the session.
+The learner-facing [Setup page](../learners/setup.md) has full installation instructions.
+
+### GitHub
+
+Both the instructor and learners should be logged into [GitHub](https://github.com).
+This is needed to access the [example repository](https://github.com/Joe-Heffer-Shef/oddsong) and to raise
+questions or issues during the workshop.
+Learners without an account can [sign up for free](https://github.com/signup).
+
+### Visual Studio Code
+
+Confirm that [Visual Studio Code](https://code.visualstudio.com/) opens and that the appropriate language extension
+is installed and active:
+
+- **Python**: the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) by Microsoft.
+- **R**: the [R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) by REditorSupport.
+
+Show learners how to open a project folder via **File → Open Folder**.
+
+### Virtual Environment (Python)
+
+For Python learners, verify they can create and activate a virtual environment before installing any packages.
+
+```bash
+python -m venv .venv
+```
+
+Activation command by platform:
+
+| Platform | Command |
+| -------- | ------- |
+| macOS / Linux | `source .venv/bin/activate` |
+| Windows (Command Prompt) | `.venv\Scripts\activate.bat` |
+| Windows (PowerShell) | `.venv\Scripts\Activate.ps1` |
+
+The shell prompt should show `(.venv)` once the environment is active.

--- a/instructors/instructor-notes.md
+++ b/instructors/instructor-notes.md
@@ -2,14 +2,13 @@
 title: 'Instructor Notes'
 ---
 
+The presentation of this course should be adapted to the target audience. Beginner researchers may not
+need advanced topics such as automatically generating and deploying documentation websites; those episodes
+can be skipped, but the material is included here if required.
+
 ## Slides
 
 The slides for this lesson are available on [Google Slides](https://docs.google.com/presentation/d/1XFIGfwBwOAxAW1strp3riXYyqFfw7AoQhg1LLKKvT8k/edit?usp=sharing).
-
-The presentation course of this course should be modified depending on the target audience.
-
-Many beginner coders in the research world will not need to know advanced skills such as how to automatically generate
-and deploy documentation websites, but some introductory material on this topic is here if required.
 
 ## System Setup
 
@@ -18,14 +17,14 @@ The learner-facing [Setup page](../learners/setup.md) has full installation inst
 
 ### GitHub
 
-Both the instructor and learners should be logged into [GitHub](https://github.com).
+Ensure all learners are logged into [GitHub](https://github.com).
 This is needed to access the [example repository](https://github.com/Joe-Heffer-Shef/oddsong) and to raise
 questions or issues during the workshop.
 Learners without an account can [sign up for free](https://github.com/signup).
 
 ### Visual Studio Code
 
-Confirm that [Visual Studio Code](https://code.visualstudio.com/) opens and that the appropriate language extension
+Verify that [Visual Studio Code](https://code.visualstudio.com/) opens and that the appropriate language extension
 is installed and active:
 
 - **Python**: the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) by Microsoft.
@@ -50,3 +49,18 @@ Activation command by platform:
 | Windows (PowerShell) | `.venv\Scripts\Activate.ps1` |
 
 The shell prompt should show `(.venv)` once the environment is active.
+
+**Note:** Python must be available (any distribution, including Anaconda) for learners who will use
+`mkdocs` to build documentation websites. Confirm this early — learners without Python cannot complete
+that episode.
+
+### Package Installation (R)
+
+R learners do not need a virtual environment. Confirm that R and the R extension for VS Code are
+working, then check that learners can install packages with `install.packages()`.
+
+If the workshop uses `renv` for reproducible environments, verify that learners can run:
+
+```r
+renv::restore()
+```

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -8,6 +8,12 @@ An example project is available on GitHub at
 [Joe-Heffer-Shef/oddsong](https://github.com/Joe-Heffer-Shef/oddsong). Throughout the course, we will build a similar
 collection of scripts. Refer to this example as you work through the course.
 
+## GitHub account
+
+This course uses [GitHub](https://github.com/) to host and share code. Please
+[sign up for a free GitHub account](https://github.com/signup) if you do not already have one, and
+[sign in](https://github.com/login) before the course begins.
+
 ## Software Setup
 
 You can complete this course using *either* Python **or** R — choose whichever you prefer.
@@ -26,7 +32,10 @@ visualization, and data analysis. The most popular tool for working with R is
 #### Text editor
 
 [Visual Studio Code](https://code.visualstudio.com/) is a free, open-source editor with excellent support for Python,
-R, and many other languages. It is the recommended editor for this course.
+R, and many other languages. It is the recommended editor for this course. To enable syntax highlighting and
+IntelliSense (autocompletion and tooltips), install the
+[Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and/or the
+[R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) from the VS Code Marketplace.
 
 Notepad is installed by default on Windows. [Notepad++](https://notepad-plus-plus.org/) is a more powerful, open-source
 alternative with syntax highlighting.
@@ -55,7 +64,10 @@ libraries needed for this course.
 #### Text editor
 
 [Visual Studio Code](https://code.visualstudio.com/) is a free, open-source editor with excellent support for Python,
-R, and many other languages. It is the recommended editor for this course.
+R, and many other languages. It is the recommended editor for this course. To enable syntax highlighting and
+IntelliSense (autocompletion and tooltips), install the
+[Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and/or the
+[R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) from the VS Code Marketplace.
 
 TextEdit is installed by default on macOS.
 
@@ -77,7 +89,10 @@ See the [using Python on a Mac](https://docs.python.org/3/using/mac.html) guide 
 #### Text editor
 
 [Visual Studio Code](https://code.visualstudio.com/) is a free, open-source editor with excellent support for Python,
-R, and many other languages. It is the recommended editor for this course.
+R, and many other languages. It is the recommended editor for this course. To enable syntax highlighting and
+IntelliSense (autocompletion and tooltips), install the
+[Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and/or the
+[R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) from the VS Code Marketplace.
 
 GNOME Text Editor is the default editor on Ubuntu 22.10 and later. Other distributions ship alternatives such as Gedit
 or Kate.

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -37,10 +37,7 @@ IntelliSense (autocompletion and tooltips), install the
 [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and/or the
 [R extension](https://marketplace.visualstudio.com/items?itemName=REditorSupport.r) from the VS Code Marketplace.
 
-Notepad is installed by default on Windows. [Notepad++](https://notepad-plus-plus.org/) is a more powerful, open-source
-alternative with syntax highlighting.
-
-At the University of Sheffield, Notepad++, Visual Studio Code, and
+At the University of Sheffield, Visual Studio Code and
 [RStudio Desktop](https://posit.co/download/rstudio-desktop/) are available on managed computers via the
 [Software Centre](https://students.sheffield.ac.uk/it-services/software/university-applications)
 desktop shortcut.


### PR DESCRIPTION
## Summary

- Adds a **System Setup** pre-flight section to instructor notes covering GitHub login, VS Code extensions, and Python virtual environment activation steps
- Adds a **GitHub account** section to the learner setup page with sign-up/sign-in links
- Extends VS Code text editor guidance with extension installation instructions (Python and R extensions) across all three platform sections
- Adds a **code of conduct** challenge to the contributors episode
- Updates `CLAUDE.md` to document `pixi` task commands for building, serving, linting, and spellchecking

## Test plan

- [x] Review instructor notes system setup section for accuracy and completeness
- [x] Verify learner setup page GitHub account section renders correctly
- [x] Check VS Code extension links are valid in all three platform sections
- [x] Confirm code of conduct challenge callout renders with correct Carpentries styling
- [x] Run `pixi run lint` and `pixi run spellcheck` to confirm no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)